### PR TITLE
Allow the template containing directory to be excluded from the output path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,7 @@ If you specify a folder as a template, then the folder will be created in the ou
 
 Cookiecutter will recursively copy all files within your templates folder and replace any occurrences of your specified fields.
 
-If you don't want this behavior, specify a file as your template's `templatePath`.
+The default behavior is to add a new folder at the destination; `destinationPath/ComponentName`. This can be avoided by adding `excludeDirectory: true` to your configuration file.
 
 ## Custom config location
 

--- a/src/lib/renderer.js
+++ b/src/lib/renderer.js
@@ -15,6 +15,7 @@ function replaceFields(string, fields) {
 
 function renderFiles({templateName, fields}, configLocation) {
     const config = getTemplateConfig(templateName, configLocation);
+    const excludeDirectory = config.excludeDirectory || false;
     const pwd = process.env.PWD;
     const destinationDirectory = path.resolve(pwd, config.outputPath);
     const templateDirectory = path.resolve(pwd, config.templatePath);
@@ -51,11 +52,11 @@ function renderFiles({templateName, fields}, configLocation) {
 
         if (isFolderTemplate) {
             const {base} = path.parse(templateDirectory);
-
             return {
                 src: filePath,
                 dest: path.join(
-                    replaceFields(base, fields),
+                    destinationDirectory,
+                    (!excludeDirectory ? replaceFields(base, fields) : ''),
                     replaceFields(filePath.replace(templateDirectory, ''), fields)
                 ),
             };

--- a/src/lib/renderer.js
+++ b/src/lib/renderer.js
@@ -55,7 +55,6 @@ function renderFiles({templateName, fields}, configLocation) {
             return {
                 src: filePath,
                 dest: path.join(
-                    destinationDirectory,
                     replaceFields(base, fields),
                     replaceFields(filePath.replace(templateDirectory, ''), fields)
                 ),

--- a/src/lib/tests/__snapshots__/renderer.test.js.snap
+++ b/src/lib/tests/__snapshots__/renderer.test.js.snap
@@ -29,6 +29,25 @@ exports[`renderFiles() should correctly render the files when the template is a 
 "
 `;
 
+exports[`renderFiles() should correctly render the files when the template is a folder excluding the containing directory if set 1`] = `
+"console.log('Bar');
+"
+`;
+
+exports[`renderFiles() should correctly render the files when the template is a folder excluding the containing directory if set 2`] = `
+"import React from 'react';
+
+const number = A;
+
+class Bar React.Component {
+    render() {
+        return <div>Hello world {number}</div>;
+    }
+}
+
+export default Bar"
+`;
+
 exports[`renderFiles() should correctly render the files when the template is just a path 1`] = `
 "import React from 'react';
 
@@ -41,4 +60,4 @@ class Baz React.Component {
 export default Baz"
 `;
 
-exports[`renderFiles() should throw an error if the output of a template allready exists 1`] = `"src/lib/tests/test-templates-output/Bar/index.js already exists."`;
+exports[`renderFiles() should throw an error if the output of a template already exists 1`] = `"src/lib/tests/test-templates-output/Bar/index.js already exists."`;

--- a/src/lib/tests/renderer.test.js
+++ b/src/lib/tests/renderer.test.js
@@ -58,7 +58,29 @@ describe('renderFiles()', () => {
         expect(fs.readFileSync(`${outputPath }/Bar/sub-folder/Bar.js`, 'utf8')).toMatchSnapshot();
     });
 
-    it('should throw an error if the output of a template allready exists', () => {
+    it('should correctly render the files when the template is a folder excluding the containing directory if set', () => {
+
+        getTemplateConfig.mockImplementation(() => {
+            return {
+                templatePath: `${__dirname }/test-templates/Foo`,
+                excludeDirectory: true,
+                outputPath,
+            };
+        });
+
+        renderFiles({
+            templateName: '',
+            fields: {
+                COMPONENT_NAME: 'Bar',
+                specialNumber: 'A',
+            },
+        });
+
+        expect(fs.readFileSync(`${outputPath }/Bar/Bar.js`, 'utf8')).toMatchSnapshot();
+        expect(fs.readFileSync(`${outputPath }/index.js`, 'utf8')).toMatchSnapshot();
+    });
+
+    it('should throw an error if the output of a template already exists', () => {
 
         getTemplateConfig.mockImplementation(() => {
             return {

--- a/src/lib/tests/test-templates/Foo/COMPONENT_NAME/COMPONENT_NAME.js
+++ b/src/lib/tests/test-templates/Foo/COMPONENT_NAME/COMPONENT_NAME.js
@@ -1,0 +1,1 @@
+console.log('COMPONENT_NAME');

--- a/src/lib/tests/test-templates/Foo/index.js
+++ b/src/lib/tests/test-templates/Foo/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const number = specialNumber;
+
+class COMPONENT_NAME React.Component {
+    render() {
+        return <div>Hello world {number}</div>;
+    }
+}
+
+export default COMPONENT_NAME


### PR DESCRIPTION
Currently when a template is output, the directory within the template directory is automatically added to the output path. This means you can't use it to output templates where the output directory is the root and sub-folders are `./src` and `./test` for example.

The optional `excludeDirectory` config parameter adds the ability to not output the template directory in the output path. Which means the library can be used on a much more diverse set of codebases.