### PR TITLE
fix: powershell

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -99,7 +99,7 @@ function validate(schema, config, key = ROOT_KEY) {
 }
 
 function getConfig(configPath = 'cookiecutter.config.js') {
-    const pwd = process.env.PWD;
+    const pwd = process.cwd();
     const config = require(path.join(pwd, configPath));
     return validateConfig(config);
 }

--- a/src/lib/renderer.js
+++ b/src/lib/renderer.js
@@ -15,7 +15,7 @@ function replaceFields(string, fields) {
 
 function renderFiles({templateName, fields}, configLocation) {
     const config = getTemplateConfig(templateName, configLocation);
-    const pwd = process.env.PWD;
+    const pwd = process.cwd();
     const destinationDirectory = path.resolve(pwd, config.outputPath);
     const templateDirectory = path.resolve(pwd, config.templatePath);
     const isFolderTemplate = isDirectory(templateDirectory);


### PR DESCRIPTION
Powershell on Windows doesn't provide the PWD environment variable.  The `cwd()` method will provide the current path and seems to solve this.